### PR TITLE
added titleid lookup map for handling game patches

### DIFF
--- a/daemon/source/game_patch_thread.cpp
+++ b/daemon/source/game_patch_thread.cpp
@@ -12,6 +12,7 @@
 #include "print.hpp"
 
 #include "pad.hpp"
+#include "titleid_map.hpp"
 
 extern "C"
 {

--- a/daemon/source/game_patch_thread.cpp
+++ b/daemon/source/game_patch_thread.cpp
@@ -768,7 +768,7 @@ static void TestCallback(void *args) {
 	(void) args;
 }
 
-static constexpr TitleIdMap TITLEID_HANDLERS{{
+static constexpr __attribute__ ((used)) TitleIdMap TITLEID_HANDLERS{{
 	{TestCallback, "BREW00000"_tid},
 	{TestCallback, {"BREW00001"}}
 }};

--- a/daemon/source/game_patch_thread.cpp
+++ b/daemon/source/game_patch_thread.cpp
@@ -551,7 +551,7 @@ void *GamePatch_Thread(void *unused)
 						ResumeApp(app_pid);
 					}
 					else if ((startsWith(app->titleId().c_str(), "CUSA18097") ||
-							  startsWith(app->titleId().c_str(), "CUSA18100") || 
+							  startsWith(app->titleId().c_str(), "CUSA18100") ||
 							  startsWith(app->titleId().c_str(), "CUSA19278")) &&
 							 (startsWith(app_ver, "01.04")))
 					{
@@ -762,3 +762,12 @@ void *GamePatch_Thread(void *unused)
 
 #undef _MAX_PATH
 #undef startsWith
+
+static void TestCallback(void *args) {
+	(void) args;
+}
+
+static constexpr TitleIdMap TITLEID_HANDLERS{{
+	{TestCallback, "BREW00000"_tid},
+	{TestCallback, {"BREW00001"}}
+}};

--- a/daemon/source/titleid_map.hpp
+++ b/daemon/source/titleid_map.hpp
@@ -137,6 +137,6 @@ class TitleIdMap {
 			if (index < 0) {
 				return nullptr;
 			}
-			return entries.get() + index;
+			return entries.array + index;
 		}
 };

--- a/daemon/source/titleid_map.hpp
+++ b/daemon/source/titleid_map.hpp
@@ -1,0 +1,144 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef void (*GameHandler)(void *args);
+
+struct TitleId {
+	static constexpr auto TITLEID_LENGTH = 10;
+	char id[TITLEID_LENGTH]{};
+
+	constexpr int_fast64_t operator<=>(const TitleId& rhs) const {
+		const auto a = __builtin_bit_cast(Helper, id);
+		const auto b = __builtin_bit_cast(Helper, rhs.id);
+		return a <=> b;
+	}
+
+	private:
+		struct __attribute__((packed)) Helper {
+			int_fast64_t low;
+			uint16_t hi;
+			constexpr int_fast64_t operator<=>(const Helper& rhs) const {
+				const auto i = low - rhs.low;
+				if (i == 0) [[unlikely]] {
+					return hi - rhs.hi;
+				}
+		    	return i;
+			}
+		};
+
+		static_assert(sizeof(Helper) == TITLEID_LENGTH);
+};
+
+constexpr TitleId operator"" _tid(const char *str, unsigned long len) {
+	// this will cause an error at compile time if the string is too long
+	TitleId tmp{};
+	__builtin_memcpy(tmp.id, str, len);
+	return tmp;
+}
+
+struct TitleIdKeyValue {
+	GameHandler handler = nullptr;
+	TitleId id{};
+
+	constexpr int_fast64_t operator<=>(const TitleIdKeyValue &rhs) const {
+		return id <=> rhs.id;
+	}
+};
+
+template <size_t N>
+struct TitleIdKeyValueArray {
+	// aggregate for compile time sorting
+	TitleIdKeyValue array[N];
+
+	constexpr TitleIdKeyValueArray(const TitleIdKeyValue (&array)[N]) {
+		__builtin_memcpy(this->array, array, sizeof(array));
+	}
+
+	constexpr TitleIdKeyValue &operator[](size_t i) {
+		return array[i];
+	}
+
+	constexpr const TitleIdKeyValue &operator[](size_t i) const {
+		return array[i];
+	}
+};
+
+constexpr void swap(TitleIdKeyValue& lhs, TitleIdKeyValue& rhs) {
+	TitleIdKeyValue tmp = rhs;
+	rhs = lhs;
+	lhs = tmp;
+}
+
+template <size_t N>
+constexpr void doSort(TitleIdKeyValueArray<N> &array, size_t left, size_t right) {
+	if (left < right) {
+		size_t m = left;
+
+		for (size_t i = left + 1; i < right; i++) {
+			if (array[i] < array[left]) {
+				swap(array[++m], array[i]);
+			}
+		}
+
+		swap(array[left], array[m]);
+
+		doSort(array, left, m);
+		doSort(array, m + 1, right);
+	}
+}
+
+template <size_t N>
+constexpr TitleIdKeyValueArray<N> sort(const TitleIdKeyValue (&array)[N]) {
+	TitleIdKeyValueArray<N> sorted = array;
+	doSort(sorted, 0, N);
+	return sorted;
+}
+
+template <size_t N>
+class TitleIdMap {
+	// this implementation is stupid
+	// don't try this one at home
+
+	friend struct SymbolLookupTable;
+
+	TitleIdKeyValueArray<N> entries;
+	// there is no intention of ever growing this since the symtab size is known
+
+	constexpr int_fast64_t binarySearch(const TitleId &key) const {
+		int_fast64_t lo = 0;
+		int_fast64_t hi = static_cast<int_fast64_t>(N) - 1;
+
+		while (lo <= hi) {
+			const auto m = (lo + hi) >> 1;
+			const auto n = entries[m].id <=> key;
+
+			if (n == 0) [[unlikely]] {
+				return m;
+			}
+
+			if (n < 0) {
+				lo = m + 1;
+			}
+			else {
+				hi = m - 1;
+			}
+		}
+		return -(lo + 1);
+	}
+
+	constexpr static int_fast64_t toIndex(int_fast64_t i) {
+		return -(i + 1);
+	}
+
+	public:
+		constexpr TitleIdMap(const TitleIdKeyValue (&array)[N]) : entries{sort(array)} {}
+		static constexpr auto length() { return N; }
+
+		constexpr const TitleIdKeyValue *operator[](const TitleId &key) const {
+			auto index = binarySearch(key);
+			if (index < 0) {
+				return nullptr;
+			}
+			return entries.get() + index;
+		}
+};

--- a/daemon/source/titleid_map.hpp
+++ b/daemon/source/titleid_map.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -30,9 +32,10 @@ struct TitleId {
 };
 
 constexpr TitleId operator"" _tid(const char *str, unsigned long len) {
-	// this will cause an error at compile time if the string is too long
 	TitleId tmp{};
-	__builtin_memcpy(tmp.id, str, len);
+	// this will cause an error at compile time if the string is too long
+	// include the null terminator
+	__builtin_memcpy(tmp.id, str, len + 1);
 	return tmp;
 }
 
@@ -96,13 +99,9 @@ constexpr TitleIdKeyValueArray<N> sort(const TitleIdKeyValue (&array)[N]) {
 
 template <size_t N>
 class TitleIdMap {
-	// this implementation is stupid
-	// don't try this one at home
-
 	friend struct SymbolLookupTable;
 
 	TitleIdKeyValueArray<N> entries;
-	// there is no intention of ever growing this since the symtab size is known
 
 	constexpr int_fast64_t binarySearch(const TitleId &key) const {
 		int_fast64_t lo = 0;
@@ -118,8 +117,7 @@ class TitleIdMap {
 
 			if (n < 0) {
 				lo = m + 1;
-			}
-			else {
+			} else {
 				hi = m - 1;
 			}
 		}


### PR DESCRIPTION
Just change the signature of `GameHandler` to suit your needs.

I didn't test this but you should be able to check the map in Ghidra after building. If it is properly sorted (by numeric value uint64_t and uint16_t not alphabetical) then it should function correctly.