### PR TITLE
Update bloodborne dlc unlock patch + remove motion blur and Chromatic Aberration patch

### DIFF
--- a/daemon/source/game_patch.cpp
+++ b/daemon/source/game_patch.cpp
@@ -144,7 +144,7 @@ void DoPatch_Bloodborne109(pid_t app_pid, uint64_t text_base)
 	write_wstring(app_pid, NO_ASLR(0x04cb39ea), L"This 60fps patch was");
 	write_wstring(app_pid, NO_ASLR(0x04cb39a4), L"Made with love, by Lance McDonald");
 	// Patch DLC Save Requirement
-	write_bytes(app_pid, NO_ASLR(0x023b6d20), "b801000000");
+	write_bytes(app_pid, NO_ASLR(0x023b55a6), "c6059f3317030190");
 	// yoink `assert()`
 	write_bytes(app_pid, NO_ASLR(0x02fbf178), "4831c0c3");
 	// no motion blur

--- a/daemon/source/game_patch.cpp
+++ b/daemon/source/game_patch.cpp
@@ -148,9 +148,9 @@ void DoPatch_Bloodborne109(pid_t app_pid, uint64_t text_base)
 	// yoink `assert()`
 	write_bytes(app_pid, NO_ASLR(0x02fbf178), "4831c0c3");
 	// no motion blur
-	write_bytes(app_pid, NO_ASLR(0x026a057b), "eb16");
+	// write_bytes(app_pid, NO_ASLR(0x026a057b), "eb16");
 	// no Chromatic Aberration
-	write_bytes(app_pid, NO_ASLR(0x0269faa8), "c783ac000000000000009090");
+	// write_bytes(app_pid, NO_ASLR(0x0269faa8), "c783ac000000000000009090");
 	// Debug Camera
 	/*
 	write_bytes(app_pid, NO_ASLR(0x01972998), "7416");


### PR DESCRIPTION
This new dlc fix is updated to work more as a runtime patch.

Some people don't want the last two patch for some reason